### PR TITLE
fix: day chart values

### DIFF
--- a/surveys/views.py
+++ b/surveys/views.py
@@ -104,7 +104,7 @@ def questions_view(request, slug):
         obj = Survey.objects.get(slug=slug)
         for question in obj.get_top_questions(interval):
             labels.append(question.slug)
-            data.append(question.user_choices_count)
+            data.append(question.count)
         responsedict = {
             'data': data,
             'labels': labels


### PR DESCRIPTION
If this PR is applied it will fix #9 :

The chart was showing the **user_choices_count** values which count all choices.
To fix this bug, we should use the **count** property from the annotate operation.